### PR TITLE
Create package for vivarium-cell

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,8 @@
+include requirements.txt
+include README.md
+include cell/bigg_models/*.json
+include cell/data/flat/*.fa
+include cell/data/flat/*.tsv
+include cell/data/flat/media/*.tsv
+include cell/data/json_files/*.json
+include cell/reference_data/*.csv

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("README.md", 'r') as readme:
 
 setup(
     name='vivarium-cell',
-    version='0.0.1',
+    version='0.0.2',
     packages=[
         'cell',
         'cell.bigg_models',

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,8 @@ from distutils.core import setup
 with open("README.md", 'r') as readme:
     long_description = readme.read()
 
+# to include data in the package, use MANIFEST.in
+
 setup(
     name='vivarium-cell',
     version='0.0.1',
@@ -33,13 +35,6 @@ setup(
         'console_scripts': []},
     long_description=long_description,
     long_description_content_type='text/markdown',
-    package_data={
-        'cell.bigg_models': ['*.json'],
-        'cell.data.flat': ['*.tsv', '*.fa'],
-        'cell.data.flat.media': ['*.tsv'],
-        'cell.data.json_files': ['*.json'],
-        'cell.reference_data': ['*.csv']},
-    include_package_data=True,
     install_requires=[
         'vivarium-core>=0.0.12',
         'cobra',

--- a/setup.py
+++ b/setup.py
@@ -11,18 +11,34 @@ setup(
     version='0.0.1',
     packages=[
         'cell',
+        'cell.bigg_models',
         'cell.compartments',
-        'cell.processes'
+        'cell.data',
+        'cell.data.chromosomes',
+        'cell.data.flat',
+        'cell.data.flat.media',
+        'cell.data.json_files',
+        'cell.experiments',
+        'cell.library',
+        'cell.plots',
+        'cell.processes',
+        'cell.reference_data',
+        'cell.states'
     ],
     author='Eran Agmon, Ryan Spangler',
-    author_email='eagmon@stanford.edu, spanglry@stanford.edu',
+    author_email='eagmon@stanford.edu, ryan.spangler@gmail.com',
     url='https://github.com/vivarium-collective/vivarium-cell',
     license='MIT',
     entry_points={
         'console_scripts': []},
     long_description=long_description,
     long_description_content_type='text/markdown',
-    package_data={},
+    package_data={
+        'cell.bigg_models': ['*.json'],
+        'cell.data.flat': ['*.tsv', '*.fa'],
+        'cell.data.flat.media': ['*.tsv'],
+        'cell.data.json_files': ['*.json'],
+        'cell.reference_data': ['*.csv']},
     include_package_data=True,
     install_requires=[
         'vivarium-core>=0.0.12',


### PR DESCRIPTION
This PR updates setup.py to include the package data, using MANIFEST.in, not the `package_data` key in setup.py, which apparently only operates for binary releases. 