### PR TITLE
remove initial_agent from diffusion_field, clean up ode_expression

### DIFF
--- a/cell/composites/lattice.py
+++ b/cell/composites/lattice.py
@@ -97,7 +97,6 @@ class Lattice(Generator):
         'multibody': {
             'bounds': [10, 10],
             'size': [10, 10],
-            'agents': {}
         },
         'diffusion': {
             'molecules': ['glc'],

--- a/cell/processes/multibody_physics.py
+++ b/cell/processes/multibody_physics.py
@@ -122,7 +122,6 @@ class Multibody(Process):
 
     name = NAME
     defaults = {
-        'agents': {},
         'jitter_force': 1e-3,  # pN
         'agent_shape': 'segment',
         'bounds': DEFAULT_BOUNDS,

--- a/cell/processes/ode_expression.py
+++ b/cell/processes/ode_expression.py
@@ -274,8 +274,7 @@ class ODE_expression(Process):
         internal_update = {}
         # transcription: dM/dt = k_M - d_M * M
         # M: conc of mRNA, k_M: transcription rate, d_M: degradation rate
-        for transcript, baseline_rate in self.transcription.items():
-            rate = 0.0
+        for transcript, rate in self.transcription.items():
             # do not transcribe regulated genes (rate = 0), except for transcriptional leaks
             if regulation_condition.get(transcript, False):
                 # leak probability as function of the time step
@@ -283,9 +282,9 @@ class ODE_expression(Process):
                 leak_probability = 1 - math.exp(-leak_rate * timestep)
                 if random.uniform(0, 1) < leak_probability:
                     rate = self.transcription_leak_magnitude
-                    print('TRANSCRIPTION LEAK!')
-            else:
-                rate = baseline_rate
+                    # print('TRANSCRIPTION LEAK!')
+                else:
+                    rate = 0.0
 
             transcript_state = internal_state[transcript]
             internal_update[transcript] = \

--- a/cell/processes/ode_expression.py
+++ b/cell/processes/ode_expression.py
@@ -282,7 +282,6 @@ class ODE_expression(Process):
                 leak_probability = 1 - math.exp(-leak_rate * timestep)
                 if random.uniform(0, 1) < leak_probability:
                     rate = self.transcription_leak_magnitude
-                    # print('TRANSCRIPTION LEAK!')
                 else:
                     rate = 0.0
 

--- a/cell/processes/ode_expression.py
+++ b/cell/processes/ode_expression.py
@@ -265,7 +265,7 @@ class ODE_expression(Process):
     def next_update(self, timestep, states):
         internal_state = states['internal']
 
-        # get condition of regulated transcripts (True/False)
+        # get current condition of regulated genes (True/False)
         flattened_states = tuplify_port_dicts(states)
         regulation_condition = {}
         for gene_id, reg_logic in self.regulation.items():
@@ -332,8 +332,10 @@ def get_lacy_config():
     regulators = [
         ('external', 'glc__D_e'),
         ('internal', 'lcts_p')]
-    regulation = {
-        'lacy_RNA': 'if (external, glc__D_e) > 0.1 and (internal, lcts_p) < 0.01'} # inhibited in this condition
+    regulation_condition = {
+        'lacy_RNA': 'if [(external, glc__D_e) > 0.005 '  # limiting concentration of glc at 0.005 mM (Boulineau 2013)
+                    'or (internal, lcts_p) < 0.005]'  # internal lcts is hypothesized to disinhibit lacY transcription
+    }
     transcription_leak = {
         'rate': 1e-4,
         'magnitude': 1e-6,
@@ -354,7 +356,7 @@ def get_lacy_config():
         'degradation_rates': degradation_rates,
         'protein_map': protein_map,
         'regulators': regulators,
-        'regulation': regulation,
+        'regulation': regulation_condition,
         'transcription_leak': transcription_leak,
         'initial_state': initial_state}
 


### PR DESCRIPTION
This PR accomplishes two unrelated goals: 1) the ```initial_agent``` is removed from diffusion field to avoid an hardcoded agent schema -- all agents should be handled by the ```agents``` ```subschema```. 2) ```ode_expression``` process is cleaned up a bit to make it more readable, and include reported parameter values for lacY expression.