### PR TITLE
Antibiotics Fixes

### DIFF
--- a/vivarium_cell/processes/antibiotic_transport.py
+++ b/vivarium_cell/processes/antibiotic_transport.py
@@ -38,6 +38,7 @@ class AntibioticTransport(ConvenienceKinetics):
         'initial_internal_antibiotic': 0,
         'initial_external_antibiotic': 1,
         'initial_pump': 1,
+        'global_deriver_key': 'global_deriver',
     }
 
     def __init__(self, initial_parameters=None):
@@ -87,7 +88,8 @@ class AntibioticTransport(ConvenienceKinetics):
                     parameters['pump_key']: parameters['initial_pump'],
                 },
             },
-            'port_ids': ['internal', 'external', 'pump_port']
+            'port_ids': ['internal', 'external', 'pump_port'],
+            'global_deriver_key': parameters['global_deriver_key'],
         }
 
         super(AntibioticTransport, self).__init__(kinetics_parameters)

--- a/vivarium_cell/processes/convenience_kinetics.py
+++ b/vivarium_cell/processes/convenience_kinetics.py
@@ -263,7 +263,6 @@ class ConvenienceKinetics(Process):
         for state in self.kinetic_rate_laws.reaction_ids:
             schema['fluxes'][state] = {
                 '_default': 0.0,
-                '_emit': False,
                 '_updater': 'set',
             }
 
@@ -271,7 +270,6 @@ class ConvenienceKinetics(Process):
         schema['global'] = {
             'mmol_to_counts': {
                 '_default': 0.0 * units.L / units.mmol,
-                '_emit': False,
             },
             'location': {
                 '_default': [0.5, 0.5],
@@ -310,7 +308,7 @@ class ConvenienceKinetics(Process):
         # kinetic rate law requires a flat dict with ('port', 'state') keys.
         flattened_states = remove_units(tuplify_port_dicts(states))
 
-        # get flux
+        # get flux, which is in units of mmol / L
         fluxes = self.kinetic_rate_laws.get_fluxes(flattened_states)
 
         # make the update

--- a/vivarium_cell/processes/diffusion_cell_environment_ficks.py
+++ b/vivarium_cell/processes/diffusion_cell_environment_ficks.py
@@ -56,6 +56,7 @@ class CellEnvironmentDiffusionFicks(Process):
                 molecule: {
                     '_default': np.full(
                         (1, 1), self.parameters['default_default']),
+                    '_divider': 'no_divide',
                 }
                 for molecule in self.parameters['molecules_to_diffuse']
             },
@@ -74,12 +75,15 @@ class CellEnvironmentDiffusionFicks(Process):
             'dimensions': {
                 'bounds': {
                     '_default': [1, 1],
+                    '_divider': 'no_divide',
                 },
                 'n_bins': {
                     '_default': [1, 1],
+                    '_divider': 'no_divide',
                 },
                 'depth': {
                     '_default': 1,
+                    '_divider': 'no_divide',
                 },
             },
         }


### PR DESCRIPTION
Minor fixes to the antibiotics processes:

* Allow specifying the global deriver key in `antibiotic_transport` so we can override the deriver in a composite
* In convenience kinetics, omit `_emit` instead of setting it to `False` so other processes in a composite can set `_emit: True`
* Specify `no_divide` divider for Ficks diffusion environment variables to make sure they never get divided