### PR TITLE
give metabolism an initial_state function

### DIFF
--- a/vivarium_cell/composites/master.py
+++ b/vivarium_cell/composites/master.py
@@ -74,7 +74,7 @@ class Master(Generator):
         # Division
         # get initial volume from metabolism
         division_config = config.get('division', {})
-        division_config.update({'initial_state': metabolism.initial_state})
+        division_config.update({'initial_state': metabolism.initial_state()})
         division = DivisionVolume(division_config)
 
         return {

--- a/vivarium_cell/plots/multibody_physics.py
+++ b/vivarium_cell/plots/multibody_physics.py
@@ -358,7 +358,7 @@ def plot_snapshots(data, plot_config):
     # make the figure
     n_rows = max(len(field_ids), 1)
     n_cols = n_snapshots + 1  # one column for the colorbar
-    figsize = (12 * n_cols, 12 * n_rows)
+    figsize = (10 * n_cols, 10 * n_rows)
     max_dpi = min([2**16 // dim for dim in figsize]) - 1
     fig = plt.figure(figsize=figsize, dpi=min(max_dpi, 100))
     grid = plt.GridSpec(n_rows, n_cols, wspace=0.2, hspace=0.2)

--- a/vivarium_cell/plots/multibody_physics.py
+++ b/vivarium_cell/plots/multibody_physics.py
@@ -358,7 +358,7 @@ def plot_snapshots(data, plot_config):
     # make the figure
     n_rows = max(len(field_ids), 1)
     n_cols = n_snapshots + 1  # one column for the colorbar
-    figsize = (10 * n_cols, 10 * n_rows)
+    figsize = (12 * n_cols, 12 * n_rows)
     max_dpi = min([2**16 // dim for dim in figsize]) - 1
     fig = plt.figure(figsize=figsize, dpi=min(max_dpi, 100))
     grid = plt.GridSpec(n_rows, n_cols, wspace=0.2, hspace=0.2)

--- a/vivarium_cell/processes/metabolism.py
+++ b/vivarium_cell/processes/metabolism.py
@@ -146,9 +146,6 @@ class Metabolism(Process):
             initial_parameters = {}
         self.nAvogadro = AVOGADRO
 
-        time_step = self.or_default(
-            initial_parameters, 'time_step')
-
         # initialize FBA
         if 'model_path' not in initial_parameters and 'stoichiometry' not in initial_parameters:
             initial_parameters['model_path'] = self.defaults['model_path']
@@ -178,16 +175,12 @@ class Metabolism(Process):
                 else:
                     self.objective_composition[mol_id] = coeff1 * coeff2
 
-        # parameters
-        parameters = {'time_step': time_step}
-        parameters.update(initial_parameters)
+        # TODO -- move this super up to the top of the init, and replace all or_default
+        super(Metabolism, self).__init__(initial_parameters)
+        self.global_deriver_key = self.parameters['global_deriver_key']
+        self.mass_deriver_key = self.parameters['mass_deriver_key']
+        self.initial_mass = self.parameters['initial_mass']
 
-        self.global_deriver_key = self.or_default(
-            initial_parameters, 'global_deriver_key')
-        self.mass_deriver_key = self.or_default(
-            initial_parameters, 'mass_deriver_key')
-
-        super(Metabolism, self).__init__(parameters)
 
     def initial_state(self, config=None):
 

--- a/vivarium_cell/processes/metabolism.py
+++ b/vivarium_cell/processes/metabolism.py
@@ -68,9 +68,10 @@ def get_minimal_media_iAF1260b(
 ):
     config = get_iAF1260b_config()
     metabolism = Metabolism(config)
+    initial_state = metabolism.initial_state()
     molecules = {
         mol_id: conc * scale_concentration
-        for mol_id, conc in metabolism.initial_state['external'].items()
+        for mol_id, conc in initial_state['external'].items()
     }
     for mol_id, conc in override_initial.items():
         molecules[mol_id] = conc
@@ -177,9 +178,21 @@ class Metabolism(Process):
                 else:
                     self.objective_composition[mol_id] = coeff1 * coeff2
 
+        # parameters
+        parameters = {'time_step': time_step}
+        parameters.update(initial_parameters)
+
+        self.global_deriver_key = self.or_default(
+            initial_parameters, 'global_deriver_key')
+        self.mass_deriver_key = self.or_default(
+            initial_parameters, 'mass_deriver_key')
+
+        super(Metabolism, self).__init__(parameters)
+
+    def initial_state(self, config=None):
+
         ## Get initial internal state from initial_mass
-        initial_metabolite_mass = self.or_default(
-            initial_parameters, 'initial_mass')
+        initial_metabolite_mass = self.parameters['initial_mass']
         mw = self.fba.molecular_weights
         composition = {
             mol_id: (-coeff if coeff < 0 else 0)
@@ -196,23 +209,12 @@ class Metabolism(Process):
         external_state.update(self.fba.minimal_external)  # optimal minimal media from fba
 
         # save initial state
-        self.initial_state = {
+        return {
             'external': external_state,
             'internal': internal_state,
             'flux_bounds': {reaction_id: self.default_upper_bound
                             for reaction_id in self.constrained_reaction_ids},
         }
-
-        # parameters
-        parameters = {'time_step': time_step}
-        parameters.update(initial_parameters)
-
-        self.global_deriver_key = self.or_default(
-            initial_parameters, 'global_deriver_key')
-        self.mass_deriver_key = self.or_default(
-            initial_parameters, 'mass_deriver_key')
-
-        super(Metabolism, self).__init__(parameters)
 
     def ports_schema(self):
         ports = [
@@ -227,10 +229,12 @@ class Metabolism(Process):
 
         schema = {port: {} for port in ports}
 
+        initial_state = self.initial_state()
+
         # internal
         for state in list(self.objective_composition.keys()):
             schema['internal'][state] = {
-                '_value': self.initial_state['internal'].get(state, 0),
+                '_value': initial_state['internal'].get(state, 0),
                 '_divider': 'split',
                 '_default': 0.0,
                 '_emit': True,
@@ -241,7 +245,7 @@ class Metabolism(Process):
         # external
         for state in self.fba.external_molecules:
             schema['external'][state] = {
-                '_default': self.initial_state['external'].get(state, 0.0),
+                '_default': initial_state['external'].get(state, 0.0),
                 '_emit': True,
             }
 
@@ -262,7 +266,7 @@ class Metabolism(Process):
         # flux_bounds
         for state in self.constrained_reaction_ids:
             schema['flux_bounds'][state] = {
-                '_default': self.initial_state['flux_bounds'].get(state, self.default_upper_bound),
+                '_default': initial_state['flux_bounds'].get(state, self.default_upper_bound),
                 '_emit': True,
             }
 

--- a/vivarium_cell/processes/metabolism.py
+++ b/vivarium_cell/processes/metabolism.py
@@ -135,7 +135,7 @@ class Metabolism(Process):
         'regulation': {},
         'initial_state': {},
         'exchange_threshold': 1e-4,  # concentrations lower than exchange_threshold are considered depleted
-        'initial_mass': 1339,  # fg
+        'initial_mass': 1339 * units.fg,
         'global_deriver_key': 'global_deriver',
         'mass_deriver_key': 'mass_deriver',
         'time_step': 1,


### PR DESCRIPTION
This migrates ```metabolism's``` use of an ```initial_state``` instance variable to an ```initial_state``` function.  There are several additional outdated style choices in ```metabolism's``` constructor that should also be updated, including the ```or_default```, and the super placed at the end rather than the beginning.

Before merging this in, I will also confirm that other repos that use metabolism are properly updated with ```initial_state```.