### PR TITLE
update to vcore 0.2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     long_description_content_type='text/markdown',
     include_package_data=True,
     install_requires=[
-        'vivarium-core>=0.1.0',
+        'vivarium-core>=0.2.0',
         'cobra',
         'Arpeggio',
         'parsimonious',


### PR DESCRIPTION
This is work to update vivarium-cell to the newer vivarium-core. Vivarium-cell still works if the older version included in `setup.py` is installed.