### PR TITLE
Deprecate Vivarium Cell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.1.5
+
+* Deprecate Vivarium Cell in favor of other libraries at
+  https://vivarium-collective.github.io.
+
 ## v0.0.24
 
 * Refactor analysis tool to make it easier for users to create their own

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # vivarium-cell
+
+**WARNING: This library has been deprecated. Please see https://vivarium-collective.github.io for alternatives.**
+
 [vivarium-cell](https://github.com/vivarium-collective/vivarium-cell) is a library of configurable
  cell process and composites for vivarium projects.
 
@@ -11,7 +14,7 @@ $ pip install vivarium-cell
 ```
 
 # Setup in local repository
-Clone the repository, make a python environment, and install dependencies. 
+Clone the repository, make a python environment, and install dependencies.
 
 First install numpy:
 ```

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("README.md", 'r') as readme:
 
 setup(
     name='vivarium-cell',
-    version='0.1.4',
+    version='0.1.5',
     packages=[
         'vivarium_cell',
         'vivarium_cell.analysis',

--- a/vivarium_cell/__init__.py
+++ b/vivarium_cell/__init__.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 
 from vivarium.library.units import Quantity, units

--- a/vivarium_cell/__init__.py
+++ b/vivarium_cell/__init__.py
@@ -19,4 +19,7 @@ from vivarium_cell.processes.local_field import LocalField
 process_registry.register(DeriveGlobals.name, DeriveGlobals)
 process_registry.register(LocalField.name, LocalField)
 
-# register updaters
+warnings.warn(
+    'Vivarium Cell is deprecated. '
+    'Please see https://vivarium-collective.github.io for alternatives.'
+)


### PR DESCRIPTION
Deprecation here involves the following:

* Add a notice to the README and CHANGELOG that the library is deprecated
* Raise a warning whenever someone imports the library. This warning looks like this:

  ```console
  $ python -c "import vivarium_cell"
  /vivarium-cell/vivarium_cell/__init__.py:24: UserWarning: Vivarium Cell is deprecated. Please see https://vivarium-collective.github.io for alternatives.
    warnings.warn(
  ```

* Update the version number so anyone using the library will see the warning when they upgrade.

Additional tasks for after this PR merges:

* Deploy the new version to PyPI
* Confirm that the deprecation warning from the README appears on PyPI
* Confirm that the deprecation warning appears in the README on GitHub
* Archive the GitHub repository